### PR TITLE
Tailwind css 적용 오류 해결

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,6 +1,4 @@
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
+@import "tailwindcss";
 
 html {
   scroll-behavior: smooth;


### PR DESCRIPTION
Update Tailwind CSS import directive in `globals.css` to correctly apply v4 styles.

The previous `@tailwind` directives were for Tailwind CSS v3, which caused styles not to be applied when using Tailwind CSS v4.

---

[Open in Web](https://www.cursor.com/agents?id=bc-66e3a066-f67c-4de7-a59d-a371e17585b8) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-66e3a066-f67c-4de7-a59d-a371e17585b8)